### PR TITLE
Add GOAWAY stream and rename ANNOUNCE_PLEASE to ANNOUNCE_SUBSCRIBE

### DIFF
--- a/draft-lcurley-moq-lite.md
+++ b/draft-lcurley-moq-lite.md
@@ -178,6 +178,8 @@ There's a 1-byte STREAM_TYPE at the beginning of each stream.
 | ------- | ------------- | ---------- |
 |    0x4  | Probe        | Subscriber  |
 | ------- | ------------- | ----------- |
+|    0x5  | Goaway       | Either      |
+| ------- | ------------- | ----------- |
 
 ### Announce
 A subscriber can open a Announce Stream to discover broadcasts matching a prefix.
@@ -226,6 +228,16 @@ The publisher SHOULD pad the connection to achieve the most recent target bitrat
 The publisher periodically replies with PROBE messages on the same bidirectional stream containing the current measured bitrate.
 
 If the publisher does not support PROBE (e.g., congestion controller is not exposed), it MUST reset the stream.
+
+### Goaway
+Either endpoint can open a Goaway Stream (0x5) to initiate a graceful session shutdown.
+
+The sender sends a GOAWAY message containing an optional new session URI.
+If the URI is non-empty, the peer SHOULD establish a new session at the provided URI and migrate any active subscriptions.
+The peer MUST NOT open new streams on the current session after receiving a GOAWAY.
+
+The sender closes the stream (FIN) when it is ready to terminate the session.
+The peer SHOULD close all streams and the session after migrating or when it no longer needs the session.
 
 # Delivery
 The most important concept in moq-lite is how to deliver a subscription.
@@ -570,6 +582,20 @@ PROBE Message {
 When sent by the subscriber (stream opener): the target bitrate in bits per second that the publisher should pad up to.
 When sent by the publisher (responder): the current measured bitrate in bits per second.
 
+## GOAWAY
+A GOAWAY message is sent to initiate a graceful session shutdown with an optional redirect.
+
+~~~
+GOAWAY Message {
+  Message Length (i)
+  New Session URI (s)
+}
+~~~
+
+**New Session URI**:
+A URI for the peer to reconnect to.
+An empty string indicates no redirect; the peer should simply close the session.
+
 ## GROUP
 The GROUP message contains information about a Group, as well as a reference to the subscription being served.
 
@@ -607,6 +633,9 @@ A generic library or relay MUST NOT inspect or modify the contents unless otherw
 
 
 # Appendix A: Changelog
+
+## moq-lite-04
+- Added GOAWAY stream for graceful session shutdown and migration.
 
 ## moq-lite-03
 - Version negotiated via ALPN (`moq-lite-xx`) instead of SETUP messages.
@@ -648,7 +677,6 @@ A quick comparison of moq-lite and moq-transport-14:
 - No paused subscriptions (forward=0)
 
 ## Deleted Messages
-- GOAWAY
 - MAX_SUBSCRIBE_ID
 - REQUESTS_BLOCKED
 - SUBSCRIBE_ERROR

--- a/draft-lcurley-moq-lite.md
+++ b/draft-lcurley-moq-lite.md
@@ -91,7 +91,7 @@ A Broadcast is a collection of Tracks from a single publisher.
 This corresponds to a MoqTransport's "track namespace".
 
 A publisher may produce multiple broadcasts, each of which is advertised via an ANNOUNCE message.
-The subscriber uses the ANNOUNCE_PLEASE message to discover available broadcasts.
+The subscriber uses the ANNOUNCE_SUBSCRIBE message to discover available broadcasts.
 These announcements are live and can change over time, allowing for dynamic origin discovery.
 
 A broadcast consists of any number of Tracks.
@@ -184,7 +184,7 @@ There's a 1-byte STREAM_TYPE at the beginning of each stream.
 ### Announce
 A subscriber can open a Announce Stream to discover broadcasts matching a prefix.
 
-The subscriber creates the stream with a ANNOUNCE_PLEASE message.
+The subscriber creates the stream with a ANNOUNCE_SUBSCRIBE message.
 The publisher replies with ANNOUNCE messages for any matching broadcasts and any future changes.
 Each ANNOUNCE message contains one of the following statuses:
 
@@ -366,11 +366,11 @@ A receiver MUST reset the stream if it receives an unknown stream type.
 Unknown stream types MUST NOT be treated as fatal; this enables extension negotiation via stream probing.
 
 
-## ANNOUNCE_PLEASE
-A subscriber sends an ANNOUNCE_PLEASE message to indicate it wants to receive an ANNOUNCE message for any broadcasts with a path that starts with the requested prefix.
+## ANNOUNCE_SUBSCRIBE
+A subscriber sends an ANNOUNCE_SUBSCRIBE message to indicate it wants to receive an ANNOUNCE message for any broadcasts with a path that starts with the requested prefix.
 
 ~~~
-ANNOUNCE_PLEASE Message {
+ANNOUNCE_SUBSCRIBE Message {
   Message Length (i)
   Broadcast Path Prefix (s),
 }
@@ -636,6 +636,7 @@ A generic library or relay MUST NOT inspect or modify the contents unless otherw
 
 ## moq-lite-04
 - Added GOAWAY stream for graceful session shutdown and migration.
+- Renamed ANNOUNCE_PLEASE to ANNOUNCE_SUBSCRIBE.
 
 ## moq-lite-03
 - Version negotiated via ALPN (`moq-lite-xx`) instead of SETUP messages.
@@ -702,7 +703,7 @@ A quick comparison of moq-lite and moq-transport-14:
 - OBJECT_DATAGRAM
 
 ## Renamed Messages
-- SUBSCRIBE_NAMESPACE -> ANNOUNCE_PLEASE
+- SUBSCRIBE_NAMESPACE -> ANNOUNCE_SUBSCRIBE
 - SUBGROUP_HEADER -> GROUP
 
 ## Deleted Fields

--- a/draft-lcurley-moq-lite.md
+++ b/draft-lcurley-moq-lite.md
@@ -225,7 +225,7 @@ A subscriber opens a Probe Stream (0x4) to measure the available bitrate of the 
 The subscriber sends a PROBE message with a target bitrate on the bidirectional stream.
 The subscriber MAY send additional PROBE messages on the same stream to update the target bitrate; the publisher MUST treat each PROBE as a new target to attempt.
 The publisher SHOULD pad the connection to achieve the most recent target bitrate.
-The publisher periodically replies with PROBE messages on the same bidirectional stream containing the current measured bitrate.
+The publisher periodically replies with PROBE messages on the same bidirectional stream containing the current estimated bitrate and smoothed RTT.
 
 If the publisher does not support PROBE (e.g., congestion controller is not exposed), it MUST reset the stream.
 
@@ -575,12 +575,18 @@ PROBE is used to measure the available bitrate of the connection.
 PROBE Message {
   Message Length (i)
   Bitrate (i)
+  RTT (i)
 }
 ~~~
 
 **Bitrate**:
 When sent by the subscriber (stream opener): the target bitrate in bits per second that the publisher should pad up to.
-When sent by the publisher (responder): the current measured bitrate in bits per second.
+When sent by the publisher (responder): the current estimated bitrate in bits per second.
+A value of 0 means unknown.
+
+**RTT**:
+The smoothed round-trip time in milliseconds, as defined in {{!RFC9002}}.
+A value of 0 means unknown.
 
 ## GOAWAY
 A GOAWAY message is sent to initiate a graceful session shutdown with an optional redirect.
@@ -637,6 +643,7 @@ A generic library or relay MUST NOT inspect or modify the contents unless otherw
 ## moq-lite-04
 - Added GOAWAY stream for graceful session shutdown and migration.
 - Renamed ANNOUNCE_PLEASE to ANNOUNCE_INTEREST.
+- Added RTT to PROBE message. Bitrate and RTT use 0 for unknown.
 
 ## moq-lite-03
 - Version negotiated via ALPN (`moq-lite-xx`) instead of SETUP messages.

--- a/draft-lcurley-moq-lite.md
+++ b/draft-lcurley-moq-lite.md
@@ -18,6 +18,7 @@ author:
 
 normative:
   moqt: I-D.ietf-moq-transport
+  RFC9002:
 
 informative:
 
@@ -601,6 +602,8 @@ GOAWAY Message {
 **New Session URI**:
 A URI for the peer to reconnect to.
 An empty string indicates no redirect; the peer should simply close the session.
+A recipient MUST validate the URI against local policy before reconnecting, including verifying the scheme, authority, and port are permitted.
+If validation fails, the recipient MUST close the session without reconnecting.
 
 ## GROUP
 The GROUP message contains information about a Group, as well as a reference to the subscription being served.

--- a/draft-lcurley-moq-lite.md
+++ b/draft-lcurley-moq-lite.md
@@ -589,6 +589,8 @@ A value of 0 means unknown.
 The smoothed round-trip time in milliseconds, as defined in {{!RFC9002}}.
 A value of 0 means unknown.
 
+> NOTE: RTT is included in the PROBE message because not all QUIC implementations and browser WebTransport APIs expose RTT statistics directly. This field may be deprecated once RTT is universally available via the underlying transport API.
+
 ## GOAWAY
 A GOAWAY message is sent to initiate a graceful session shutdown with an optional redirect.
 

--- a/draft-lcurley-moq-lite.md
+++ b/draft-lcurley-moq-lite.md
@@ -91,7 +91,7 @@ A Broadcast is a collection of Tracks from a single publisher.
 This corresponds to a MoqTransport's "track namespace".
 
 A publisher may produce multiple broadcasts, each of which is advertised via an ANNOUNCE message.
-The subscriber uses the ANNOUNCE_SUBSCRIBE message to discover available broadcasts.
+The subscriber uses the ANNOUNCE_INTEREST message to discover available broadcasts.
 These announcements are live and can change over time, allowing for dynamic origin discovery.
 
 A broadcast consists of any number of Tracks.
@@ -184,7 +184,7 @@ There's a 1-byte STREAM_TYPE at the beginning of each stream.
 ### Announce
 A subscriber can open a Announce Stream to discover broadcasts matching a prefix.
 
-The subscriber creates the stream with a ANNOUNCE_SUBSCRIBE message.
+The subscriber creates the stream with a ANNOUNCE_INTEREST message.
 The publisher replies with ANNOUNCE messages for any matching broadcasts and any future changes.
 Each ANNOUNCE message contains one of the following statuses:
 
@@ -366,11 +366,11 @@ A receiver MUST reset the stream if it receives an unknown stream type.
 Unknown stream types MUST NOT be treated as fatal; this enables extension negotiation via stream probing.
 
 
-## ANNOUNCE_SUBSCRIBE
-A subscriber sends an ANNOUNCE_SUBSCRIBE message to indicate it wants to receive an ANNOUNCE message for any broadcasts with a path that starts with the requested prefix.
+## ANNOUNCE_INTEREST
+A subscriber sends an ANNOUNCE_INTEREST message to indicate it wants to receive an ANNOUNCE message for any broadcasts with a path that starts with the requested prefix.
 
 ~~~
-ANNOUNCE_SUBSCRIBE Message {
+ANNOUNCE_INTEREST Message {
   Message Length (i)
   Broadcast Path Prefix (s),
 }
@@ -636,7 +636,7 @@ A generic library or relay MUST NOT inspect or modify the contents unless otherw
 
 ## moq-lite-04
 - Added GOAWAY stream for graceful session shutdown and migration.
-- Renamed ANNOUNCE_PLEASE to ANNOUNCE_SUBSCRIBE.
+- Renamed ANNOUNCE_PLEASE to ANNOUNCE_INTEREST.
 
 ## moq-lite-03
 - Version negotiated via ALPN (`moq-lite-xx`) instead of SETUP messages.
@@ -703,7 +703,7 @@ A quick comparison of moq-lite and moq-transport-14:
 - OBJECT_DATAGRAM
 
 ## Renamed Messages
-- SUBSCRIBE_NAMESPACE -> ANNOUNCE_SUBSCRIBE
+- SUBSCRIBE_NAMESPACE -> ANNOUNCE_INTEREST
 - SUBGROUP_HEADER -> GROUP
 
 ## Deleted Fields


### PR DESCRIPTION
## Summary
This PR introduces graceful session shutdown and migration capabilities to moq-lite, along with a clarifying rename of the announce subscription message.

## Key Changes
- **Added GOAWAY stream (0x5)**: Enables either endpoint to initiate graceful session shutdown with optional redirect to a new session URI. Peers receiving a GOAWAY must not open new streams and should migrate active subscriptions if a new URI is provided.
- **Renamed ANNOUNCE_PLEASE to ANNOUNCE_SUBSCRIBE**: More accurately reflects the purpose of the message as a subscription request for broadcast announcements rather than a request for information.
- **Updated documentation**: Added comprehensive section describing GOAWAY stream behavior, message format, and migration semantics.
- **Updated changelog**: Added moq-lite-04 entry documenting these changes.
- **Updated comparison tables**: Removed GOAWAY from "Deleted Messages" section and updated message rename references.

## Implementation Details
- GOAWAY message format includes a Message Length field and optional New Session URI string field
- Empty URI string indicates no redirect; peer should simply close the session
- Sender closes the stream (FIN) when ready to terminate the session
- Peer should close all streams and session after migrating or when no longer needed
- Stream type 0x5 is reserved for GOAWAY, with either endpoint able to initiate

https://claude.ai/code/session_01LCkQcr69mLdMHo9RQSL8xG